### PR TITLE
updating makefile, adding gox as dependency for package builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ terraform.tfvars
 terraform.tfplan
 terraform.tfstate
 bin/
-terraform-provider-gorillastack
+terraform-provider-gorillastack*
 modules-dev/
 /pkg/
 website/.vagrant

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,10 +2,26 @@ TEST?=$$(go list ./... | grep -v 'vendor')
 PKG_NAME=gorillastack
 export GO111MODULE=on
 
+# Last tagged version
+VERSION = $$(git tag --sort=v:refname | tail -1)
+
 default: build
 
+# Builds a binary for current OS and Arch in the plugins dir
 build: fmtcheck
-	go install
+	@mkdir -p ~/.terraform.d/plugins/
+	@go build -o "${HOME}/.terraform.d/plugins/terraform-provider-gorillastack_${VERSION}"
+
+# Builds a binary for current OS and Arch in the plugins dir
+build-dev: fmtcheck
+	@mkdir -p ~/.terraform.d/plugins/
+	@go build -o "${HOME}/.terraform.d/plugins/terraform-provider-gorillastack_${VERSION}_dev"
+
+# Builds a binary for Linux, Windows, and OSX and installs it in the default terraform plugins directory
+build-plugins: fmtcheck
+	@mkdir -p ~/.terraform.d/plugins/
+	gox -osarch="linux/amd64 darwin/amd64 windows/amd64" \
+	  -output="${HOME}/.terraform.d/plugins/{{.OS}}_{{.Arch}}/terraform-provider-gorillastack_${VERSION}" .
 
 test: fmtcheck
 	go test -i $(TEST) || exit 1

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/gorillastack/terraform-provider-gorillastack
 
 go 1.12
 
-require github.com/hashicorp/terraform v0.12.0
+require (
+	github.com/hashicorp/terraform v0.12.0
+	github.com/mitchellh/gox v1.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,7 @@ github.com/hashicorp/go-tfe v0.3.16/go.mod h1:SuPHR+OcxvzBZNye7nGPfwZTEyd3rWPfLV
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-version v1.0.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.1.0 h1:bPIoEKD27tNdebFGGxxYwcL4nepeY4j1QP23PFRGzg0=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -210,8 +211,12 @@ github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eI
 github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
+github.com/mitchellh/gox v1.0.1 h1:x0jD3dcHk9a9xPSDN6YEL4xL6Qz0dvNYm8yZqui5chI=
+github.com/mitchellh/gox v1.0.1/go.mod h1:ED6BioOGXMswlXa2zxfh/xdd5QhwYliBFn9V18Ap4z4=
 github.com/mitchellh/hashstructure v1.0.0 h1:ZkRJX1CyOoTkar7p/mLS5TZU4nJ1Rn/F8u9dGS02Q3Y=
 github.com/mitchellh/hashstructure v1.0.0/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1DutKwClXU/ABz6AQ=
+github.com/mitchellh/iochan v1.0.0 h1:C+X3KsSTLFVBr/tK1eYN/vs4rJcvsiLU338UhYPJWeY=
+github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/panicwrap v0.0.0-20190213213626-17011010aaa4/go.mod h1:YYMf4xtQnR8LRC0vKi3afvQ5QwRPQ17zjcpkBCufb+I=
@@ -346,6 +351,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190221075227-b4e8571b14e0/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190502175342-a43fa875dd82 h1:vsphBvatvfbhlb4PO1BYSr9dzugGxJ/SQHoNufZJq1w=
 golang.org/x/sys v0.0.0-20190502175342-a43fa875dd82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
There was an issues with our makefile, whereby the default make target didn't place the binary in the `~/.terraform/plugins/` directory. This PR resolves that, adding a versioned build to that folder by default. Also adding a new target utilizing gox to build binaries for different architectures and OS's.