### PR TITLE
fixing infinite loop in the functions to stringify the stringarrayornull type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,16 @@
-## 0.1.0 (July 8, 2019)
+## 0.2.1 (July 31, 2019)
 
 #### BREAKING CHANGES:
-
-* None
-
 #### FEATURES:
-
-* **New Resource:** Rule
-* **New Resource:** Tag Group
-
 #### IMPROVEMENTS:
 #### BUG FIXES:
+
+* Fixing an infinite loop when stringifying the StringArrayOrNull type in the context
+
 #### NOTES:
 
-* This is the initial GorillaStack Terraform provider implementation. As implied by a < 1 major version, there is little commitment to maintaining backwards compatibility right now, and there may be breaking changes in coming minor version updates. All breaking changes will be communicated in the changelog.
+* Version bumped to version 0.2.1 for this bugfixj
+
 
 ## 0.2.0 (July 26, 2019)
 
@@ -39,3 +36,21 @@
 #### NOTES:
 
 * Version bumped to version 0.2.0 as there are some minor breaking changes and significant new features, thus a patch version is not quite appropriate.
+
+
+## 0.1.0 (July 8, 2019)
+
+#### BREAKING CHANGES:
+
+* None
+
+#### FEATURES:
+
+* **New Resource:** Rule
+* **New Resource:** Tag Group
+
+#### IMPROVEMENTS:
+#### BUG FIXES:
+#### NOTES:
+
+* This is the initial GorillaStack Terraform provider implementation. As implied by a < 1 major version, there is little commitment to maintaining backwards compatibility right now, and there may be breaking changes in coming minor version updates. All breaking changes will be communicated in the changelog.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 #### NOTES:
 
-* Version bumped to version 0.2.1 for this bugfixj
+* Version bumped to version 0.2.1 for this bugfix
 
 
 ## 0.2.0 (July 26, 2019)

--- a/gorillastack/rules.go
+++ b/gorillastack/rules.go
@@ -12,10 +12,10 @@ type StringArrayOrNull struct {
 }
 
 func (s StringArrayOrNull) String() string {
-	if len(s.StringArray) == 0 {
+	if s.StringArray == nil || len(s.StringArray) == 0 {
 		return "null"
 	}
-	return util.StringValue(s)
+	return util.StringValue(s.StringArray)
 }
 
 func (s StringArrayOrNull) GoString() string {


### PR DESCRIPTION
## 0.2.1 (July 31, 2019)

#### BREAKING CHANGES:
#### FEATURES:
#### IMPROVEMENTS:
#### BUG FIXES:

* Fixing an infinite loop when stringifying the StringArrayOrNull type in the context

#### NOTES:

* Version bumped to version 0.2.1 for this bugfix