### PR TITLE
fixing issue with all accounts being selected when account groups are specified

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,7 @@ github.com/hashicorp/memberlist v0.1.0/go.mod h1:ncdBp14cuox2iFOq3kDiquKU6fqsTBc
 github.com/hashicorp/serf v0.0.0-20160124182025-e4ec8cc423bb/go.mod h1:h/Ru6tmZazX7WO/GDmwdpS975F019L4t5ng5IgwbNrE=
 github.com/hashicorp/terraform v0.12.0 h1:It2vmod2dBMB4+r+aUW2Afx0HlftyUwzNsNH3I2vrJ8=
 github.com/hashicorp/terraform v0.12.0/go.mod h1:Ke0ig9gGZ8rhV6OddAhBYt5nXmpvXsuNQQ8w9qYBZfU=
+github.com/hashicorp/terraform v0.12.6 h1:mWItQdLZQ7f3kBYBu2Kgdg+E5iZb1KtCq73V10Hmu48=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20190327195015-8022a2663a70 h1:oZm5nE11yhzsTRz/YrUyDMSvixePqjoZihwn8ipuOYI=
 github.com/hashicorp/terraform-config-inspect v0.0.0-20190327195015-8022a2663a70/go.mod h1:ItvqtvbC3K23FFET62ZwnkwtpbKZm8t8eMcWjmVVjD8=
 github.com/hashicorp/vault v0.10.4/go.mod h1:KfSyffbKxoVyspOdlaGVjIuwLobi07qD1bAbosPMpP0=

--- a/gorillastack/resource_rule_test.go
+++ b/gorillastack/resource_rule_test.go
@@ -1,0 +1,65 @@
+package gorillastack
+
+import (
+	"testing"
+
+	"github.com/gorillastack/terraform-provider-gorillastack/gorillastack/util"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func getRuleResourceData(t *testing.T, rawAwsContext map[string]interface{}) *schema.ResourceData {
+	rawListOfAwsContexts := []interface{}{rawAwsContext}
+	rawContext := map[string]interface{}{
+		"aws": rawListOfAwsContexts,
+	}
+	rawListOfContexts := []interface{}{rawContext}
+	rawRule := map[string]interface{}{"context": rawListOfContexts, "name": "testes"}
+	return schema.TestResourceDataRaw(t, ruleSchema(), rawRule)
+}
+
+func TestConstructContextAllAccountsAllRegions(t *testing.T) {
+	rawAwsContext := map[string]interface{}{
+		"platform": "aws",
+	}
+	resourceData := getRuleResourceData(t, rawAwsContext)
+	context := constructContext(resourceData)
+	result := util.StringValue(context)
+	expected := "{\"platform\":\"aws\",\"accountIds\":null,\"regions\":null}"
+
+	if result != expected {
+		t.Errorf("constructContextFromResourceData is wrong. Got: '%s' Expected: '%s'", result, expected)
+	}
+}
+
+// Want to be sure that we set an empty array for the accountIds rather than null
+func TestConstructContextAccountGroupNoAccountsSelected(t *testing.T) {
+	rawAwsContext := map[string]interface{}{
+		"platform":          "aws",
+		"account_group_ids": []string{"fake_account_group_id"},
+	}
+	resourceData := getRuleResourceData(t, rawAwsContext)
+	context := constructContext(resourceData)
+	result := util.StringValue(context)
+	expected := "{\"platform\":\"aws\",\"accountIds\":[],\"regions\":null,\"accountGroupIds\":[\"fake_account_group_id\"]}"
+
+	if result != expected {
+		t.Errorf("constructContextFromResourceData is wrong. Got: '%s' Expected: '%s'", result, expected)
+	}
+}
+
+// Want to be sure that we send an array with the selected accounts
+func TestConstructContextAccountGroupWithAccountsSelected(t *testing.T) {
+	rawAwsContext := map[string]interface{}{
+		"platform":          "aws",
+		"account_ids":       []string{"123"},
+		"account_group_ids": []string{"fake_account_group_id"},
+	}
+	resourceData := getRuleResourceData(t, rawAwsContext)
+	context := constructContext(resourceData)
+	result := util.StringValue(context)
+	expected := "{\"platform\":\"aws\",\"accountIds\":[\"123\"],\"regions\":null,\"accountGroupIds\":[\"fake_account_group_id\"]}"
+
+	if result != expected {
+		t.Errorf("constructContextFromResourceData is wrong. Got: '%s' Expected: '%s'", result, expected)
+	}
+}

--- a/gorillastack/rules.go
+++ b/gorillastack/rules.go
@@ -9,13 +9,15 @@ import (
 // This type is for fields like accountIds and regions that can either be an array of strings or null
 type StringArrayOrNull struct {
 	StringArray []*string
+	ShowEmpty   bool
 }
 
 func (s StringArrayOrNull) String() string {
-	if s.StringArray == nil || len(s.StringArray) == 0 {
-		return "null"
+	if len(s.StringArray) > 0 || s.ShowEmpty {
+		return util.StringValue(s.StringArray)
 	}
-	return util.StringValue(s.StringArray)
+
+	return "null"
 }
 
 func (s StringArrayOrNull) GoString() string {

--- a/gorillastack/rules_test.go
+++ b/gorillastack/rules_test.go
@@ -1,0 +1,47 @@
+package gorillastack
+
+import (
+	"testing"
+
+	"github.com/gorillastack/terraform-provider-gorillastack/gorillastack/util"
+)
+
+func TestStringArrayOrNullStringWhenNil(t *testing.T) {
+	input := StringArrayOrNull{StringArray: nil}
+	result := input.String()
+	expected := "null"
+	if result != expected {
+		t.Errorf("StringArrayOrNull is wrong. Got: '%s' Expected: '%s'", result, expected)
+	}
+}
+
+func TestStringArrayOrNullStringWhenEmptyArray(t *testing.T) {
+	input := StringArrayOrNull{StringArray: []*string{}}
+	result := input.String()
+	expected := "null"
+	if result != expected {
+		t.Errorf("StringArrayOrNull is wrong. Got: '%s' Expected: '%s'", result, expected)
+	}
+}
+
+func TestStringArrayOrNullStringWhenEmptyArrayAndShowEmptyTrue(t *testing.T) {
+	input := StringArrayOrNull{
+		StringArray: []*string{},
+		ShowEmpty:   true,
+	}
+	result := input.String()
+	expected := "[]"
+	if result != expected {
+		t.Errorf("StringArrayOrNull is wrong. Got: '%s' Expected: '%s'", result, expected)
+	}
+}
+
+func TestStringArrayOrNullStringWithAnArrayOfStrings(t *testing.T) {
+	strings := []string{"one", "two", "three"}
+	input := StringArrayOrNull{StringArray: util.MapAddresses(strings)}
+	result := input.String()
+	expected := "[\"one\",\"two\",\"three\"]"
+	if result != expected {
+		t.Errorf("StringArrayOrNull is wrong. Got: '%s' Expected: '%s'", result, expected)
+	}
+}

--- a/gorillastack/util/arrays.go
+++ b/gorillastack/util/arrays.go
@@ -49,3 +49,13 @@ func ConvertToArrayOfMaps(arr []interface{}) []map[string]interface{} {
 
 	return res
 }
+
+func MapAddresses(arr []string) []*string {
+	LEN := len(arr)
+	ptr := make([]*string, LEN)
+	for i := 0; i < LEN; i++ {
+		ptr[i] = &arr[i]
+	}
+
+	return ptr
+}

--- a/gorillastack/util/string_value_test.go
+++ b/gorillastack/util/string_value_test.go
@@ -13,6 +13,15 @@ func TestStringValueOnArray(t *testing.T) {
 	}
 }
 
+func TestStringValueOnArrayOfStringPointers(t *testing.T) {
+	strings := []string{"one", "two", "three"}
+	expected := "[\"one\",\"two\",\"three\"]"
+	result := StringValue(MapAddresses(strings))
+	if result != expected {
+		t.Errorf("Incorrect array stringification. Got: '%s' Expected: '%s'", result, expected)
+	}
+}
+
 type B struct {
 	WhichJeff      string
 	IsThisABadTest bool


### PR DESCRIPTION
We were selecting "all accounts by default when no accounts specified. Not the correct behaviour when account groups are specified.

Adding some tests