### PR TITLE
Add support for targeting RDS instance clusters

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,61 +1,100 @@
 TEST?=$$(go list ./... | grep -v 'vendor')
-PKG_NAME=gorillastack
-export GO111MODULE=on
+HOSTNAME=terraform.gorillastack.com
+NAMESPACE=gorillastack
+NAME=gorillastack
+BINARY=terraform-provider-${NAME}
+VERSION=0.3
+OS_ARCH=linux_amd64
 
-# Last tagged version
-VERSION = $$(git tag --sort=v:refname | tail -1)
+default: install
 
-default: build
+build:
+	go build -o ${BINARY}
+release:
+	GOOS=darwin GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_darwin_amd64
+	GOOS=freebsd GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_freebsd_386
+	GOOS=freebsd GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_freebsd_amd64
+	GOOS=freebsd GOARCH=arm go build -o ./bin/${BINARY}_${VERSION}_freebsd_arm
+	GOOS=linux GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_linux_386
+	GOOS=linux GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_linux_amd64
+	GOOS=linux GOARCH=arm go build -o ./bin/${BINARY}_${VERSION}_linux_arm
+	GOOS=openbsd GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_openbsd_386
+	GOOS=openbsd GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_openbsd_amd64
+	GOOS=solaris GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_solaris_amd64
+	GOOS=windows GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_windows_386
+	GOOS=windows GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_windows_amd64
 
-# Builds a binary for current OS and Arch in the plugins dir
-build: fmtcheck
-	@mkdir -p ~/.terraform.d/plugins/
-	@go build -o "${HOME}/.terraform.d/plugins/terraform-provider-gorillastack_${VERSION}"
+install: build
+	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
+	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 
-# Builds a binary for current OS and Arch in the plugins dir
-build-dev: fmtcheck
-	@mkdir -p ~/.terraform.d/plugins/
-	@go build -o "${HOME}/.terraform.d/plugins/terraform-provider-gorillastack_${VERSION}_dev"
+test: 
+	go test -i $(TEST) || exit 1                                                   
+	echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4                    
 
-# Builds a binary for Linux, Windows, and OSX and installs it in the default terraform plugins directory
-build-plugins: fmtcheck
-	@mkdir -p ~/.terraform.d/plugins/
-	gox -osarch="linux/amd64 darwin/amd64 windows/amd64" \
-	  -output="${HOME}/.terraform.d/plugins/{{.OS}}_{{.Arch}}/terraform-provider-gorillastack_${VERSION}" .
+testacc: 
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m   
 
-test: fmtcheck
-	go test -i $(TEST) || exit 1
-	echo $(TEST) | \
-		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
 
-testacc: fmtcheck
-	TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test $(TEST) -v $(TESTARGS) -timeout 240m -ldflags="-X=github.com/terraform-providers/terraform-provider-gorillastack/version.ProviderVersion=acc"
 
-fmt:
-	@echo "==> Fixing source code with gofmt..."
-	gofmt -w -s ./$(PKG_NAME)
+# TEST?=$$(go list ./... | grep -v 'vendor')
+# PKG_NAME=gorillastack
+# export GO111MODULE=on
 
-# Currently required by tf-deploy compile
-fmtcheck:
-	@echo "==> Checking source code against gofmt..."
-	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
+# # Last tagged version
+# VERSION = $$(git tag --sort=v:refname | tail -1)
 
-lint:
-	@echo "==> Checking source code against linters..."
-	@golangci-lint run ./$(PKG_NAME)
+# default: build
 
-tools:
-	@echo "==> installing required tooling..."
-	GO111MODULE=off go get -u github.com/client9/misspell/cmd/misspell
-	GO111MODULE=off go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+# # Builds a binary for current OS and Arch in the plugins dir
+# build: fmtcheck
+# 	@mkdir -p ~/.terraform.d/plugins/
+# 	@go build -o "${HOME}/.terraform.d/plugins/terraform-provider-gorillastack_${VERSION}"
 
-test-compile:
-	@if [ "$(TEST)" = "./..." ]; then \
-		echo "ERROR: Set TEST to a specific package. For example,"; \
-		echo "  make test-compile TEST=./$(PKG_NAME)"; \
-		exit 1; \
-	fi
-	go test -c $(TEST) $(TESTARGS)
+# # Builds a binary for current OS and Arch in the plugins dir
+# build-dev: fmtcheck
+# 	@mkdir -p ~/.terraform.d/plugins/
+# 	@go build -o "${HOME}/.terraform.d/plugins/terraform-provider-gorillastack_${VERSION}_dev"
 
-.PHONY: build test testacc vet fmt fmtcheck lint tools errcheck test-compile
+# # Builds a binary for Linux, Windows, and OSX and installs it in the default terraform plugins directory
+# build-plugins: fmtcheck
+# 	@mkdir -p ~/.terraform.d/plugins/
+# 	gox -osarch="linux/amd64 darwin/amd64 windows/amd64" \
+# 	  -output="${HOME}/.terraform.d/plugins/{{.OS}}_{{.Arch}}/terraform-provider-gorillastack_${VERSION}" .
+
+# test: fmtcheck
+# 	go test -i $(TEST) || exit 1
+# 	echo $(TEST) | \
+# 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
+
+# testacc: fmtcheck
+# 	TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test $(TEST) -v $(TESTARGS) -timeout 240m -ldflags="-X=github.com/terraform-providers/terraform-provider-gorillastack/version.ProviderVersion=acc"
+
+# fmt:
+# 	@echo "==> Fixing source code with gofmt..."
+# 	gofmt -w -s ./$(PKG_NAME)
+
+# # Currently required by tf-deploy compile
+# fmtcheck:
+# 	@echo "==> Checking source code against gofmt..."
+# 	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
+
+# lint:
+# 	@echo "==> Checking source code against linters..."
+# 	@golangci-lint run ./$(PKG_NAME)
+
+# tools:
+# 	@echo "==> installing required tooling..."
+# 	GO111MODULE=off go get -u github.com/client9/misspell/cmd/misspell
+# 	GO111MODULE=off go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+
+# test-compile:
+# 	@if [ "$(TEST)" = "./..." ]; then \
+# 		echo "ERROR: Set TEST to a specific package. For example,"; \
+# 		echo "  make test-compile TEST=./$(PKG_NAME)"; \
+# 		exit 1; \
+# 	fi
+# 	go test -c $(TEST) $(TESTARGS)
+
+# .PHONY: build test testacc vet fmt fmtcheck lint tools errcheck test-compile
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,7 +3,7 @@ HOSTNAME=terraform.gorillastack.com
 NAMESPACE=gorillastack
 NAME=gorillastack
 BINARY=terraform-provider-${NAME}
-VERSION=0.3
+VERSION = $$(git tag --sort=v:refname | tail -1)
 OS_ARCH=linux_amd64
 
 default: install
@@ -34,67 +34,3 @@ test:
 
 testacc: 
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m   
-
-
-
-# TEST?=$$(go list ./... | grep -v 'vendor')
-# PKG_NAME=gorillastack
-# export GO111MODULE=on
-
-# # Last tagged version
-# VERSION = $$(git tag --sort=v:refname | tail -1)
-
-# default: build
-
-# # Builds a binary for current OS and Arch in the plugins dir
-# build: fmtcheck
-# 	@mkdir -p ~/.terraform.d/plugins/
-# 	@go build -o "${HOME}/.terraform.d/plugins/terraform-provider-gorillastack_${VERSION}"
-
-# # Builds a binary for current OS and Arch in the plugins dir
-# build-dev: fmtcheck
-# 	@mkdir -p ~/.terraform.d/plugins/
-# 	@go build -o "${HOME}/.terraform.d/plugins/terraform-provider-gorillastack_${VERSION}_dev"
-
-# # Builds a binary for Linux, Windows, and OSX and installs it in the default terraform plugins directory
-# build-plugins: fmtcheck
-# 	@mkdir -p ~/.terraform.d/plugins/
-# 	gox -osarch="linux/amd64 darwin/amd64 windows/amd64" \
-# 	  -output="${HOME}/.terraform.d/plugins/{{.OS}}_{{.Arch}}/terraform-provider-gorillastack_${VERSION}" .
-
-# test: fmtcheck
-# 	go test -i $(TEST) || exit 1
-# 	echo $(TEST) | \
-# 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
-
-# testacc: fmtcheck
-# 	TF_ACC=1 TF_SCHEMA_PANIC_ON_ERROR=1 go test $(TEST) -v $(TESTARGS) -timeout 240m -ldflags="-X=github.com/terraform-providers/terraform-provider-gorillastack/version.ProviderVersion=acc"
-
-# fmt:
-# 	@echo "==> Fixing source code with gofmt..."
-# 	gofmt -w -s ./$(PKG_NAME)
-
-# # Currently required by tf-deploy compile
-# fmtcheck:
-# 	@echo "==> Checking source code against gofmt..."
-# 	@sh -c "'$(CURDIR)/scripts/gofmtcheck.sh'"
-
-# lint:
-# 	@echo "==> Checking source code against linters..."
-# 	@golangci-lint run ./$(PKG_NAME)
-
-# tools:
-# 	@echo "==> installing required tooling..."
-# 	GO111MODULE=off go get -u github.com/client9/misspell/cmd/misspell
-# 	GO111MODULE=off go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
-
-# test-compile:
-# 	@if [ "$(TEST)" = "./..." ]; then \
-# 		echo "ERROR: Set TEST to a specific package. For example,"; \
-# 		echo "  make test-compile TEST=./$(PKG_NAME)"; \
-# 		exit 1; \
-# 	fi
-# 	go test -c $(TEST) $(TESTARGS)
-
-# .PHONY: build test testacc vet fmt fmtcheck lint tools errcheck test-compile
-

--- a/gorillastack/resource_rule.go
+++ b/gorillastack/resource_rule.go
@@ -386,6 +386,7 @@ func constructAction(actionName string, defn map[string]interface{}) *Action {
 			Action:           &actionName,
 			TagGroups:        util.ArrayOfStringPointers(defn["tag_groups"].([]interface{})),
 			TagGroupCombiner: util.GetTagGroupCombiner(defn["tag_group_combiner"].(string)),
+			TargetClusters:   util.BoolAddress(defn["target_clusters"].(bool)),
 			Wait: &Wait{
 				InstanceState:  util.BoolAddress(defn["wait_instance_state"].(bool)),
 				InstanceStatus: util.BoolAddress(defn["wait_instance_status"].(bool)),

--- a/gorillastack/resource_rule.go
+++ b/gorillastack/resource_rule.go
@@ -135,6 +135,10 @@ func constructTrigger(d *schema.ResourceData) *Trigger {
 				MatchFields:     constructMatchFields(v["match_fields"].([]interface{})),
 				MatchExpression: constructMatchExpression(v["match_expression"].([]interface{})),
 			}
+		case "manual":
+			trigger = Trigger{
+				Trigger:		util.StringAddress("manual_trigger"),
+			}
 		default:
 			break
 		}

--- a/gorillastack/rules.go
+++ b/gorillastack/rules.go
@@ -220,6 +220,8 @@ type Action struct {
 	NotificationsTrigger *string
 	// Notify Event
 	NotificationFieldMappings []*NotificationFieldMapping
+	// Start/Stop RDS cluster instances
+	TargetClusters *bool
 }
 
 type Rule struct {

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    gorillastack = {
+      source = "terraform.gorillastack.com/gorillastack/gorillastack"
+      #
+      # For more information, see the provider source documentation:
+      #
+      # https://www.terraform.io/docs/configuration/providers.html#provider-source
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
This PR fixes the issue where specifying to target RDS instance cluster wouldn't actually produce a rule the flag set. This is an example config in the template file of how the flag can be set.

```
  actions {
    stop_rds_instances {
      target_clusters = true
      .
      .
      .
    }
  }
```