### PR TITLE
chore: .terraform.lock.hcl should not be versioned

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ example*.tf
 terraform.tfvars
 terraform.tfplan
 terraform.tfstate
-.terraform.lock*
+.terraform.lock.*
 bin/
 terraform-provider-gorillastack*
 modules-dev/

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,9 +1,0 @@
-# This file is maintained automatically by "terraform init".
-# Manual edits may be lost in future updates.
-
-provider "terraform.gorillastack.com/gorillastack/gorillastack" {
-  version = "0.3.2"
-  hashes = [
-    "h1:jSHA/e0TlmmQN7hiiioWVVXD3Z1qJEy9u3fUGru62qU=",
-  ]
-}


### PR DESCRIPTION
Shouldn't have this lock file in the repo. Fixing the `.gitignore` pattern